### PR TITLE
Fix boot by adding libgcc_s.so to initramfs

### DIFF
--- a/encrypt_install
+++ b/encrypt_install
@@ -19,6 +19,9 @@ build() {
     add_file "/usr/lib/udev/rules.d/95-dm-notify.rules"
     add_file "/usr/lib/initcpio/udev/11-dm-initramfs.rules" "/usr/lib/udev/rules.d/11-dm-initramfs.rules"
 
+    # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
+    add_binary "/usr/lib/libgcc_s.so.1"
+
     add_runscript
 }
 


### PR DESCRIPTION
This change fixes the boot on current Arch Linux. After entering the password, the boot fails due to a "pthread_create" call by `cryptsetup` which fails because libgcc is unavailable.

Taken from latest arch encrypt-hook. For details see https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/cryptsetup&id=9ec53a58a97dc23b98418b505f9b967472dc046c

With this change the hook still works fine for me in 2019. Thanks

